### PR TITLE
README.md review + imports corrected for stable-retro + correct path for sourcedata in invoke.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ git clone git@github.com:courtois-neuromod/mario.replays
 cd mario.replays
 pip install -e .
 
-# Or with airoh
+# Or with airoh (Recommended)
 pip install airoh
 invoke setup-env
+
+# Download the cneuromod mario dataset
+# For more infomation: https://docs.cneuromod.ca/en/latest/ACCESS.html
+invoke setup-mario-dataset
 
 # Process replays
 invoke create-replays

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ For each `.bk2` replay file:
 # Install
 git clone git@github.com:courtois-neuromod/mario.replays
 cd mario.replays
-pip install -r requirements.txt
 pip install -e .
 
 # Or with airoh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cd mario.replays
 pip install -e .
 
 # Or with airoh (Recommended)
-pip install airoh
+pip install airoh invoke
 invoke setup-env
 
 # Download the cneuromod mario dataset

--- a/code/mario_replays/create_replays/create_replays.py
+++ b/code/mario_replays/create_replays/create_replays.py
@@ -12,7 +12,7 @@ Usage:
 import argparse
 import os
 import os.path as op
-import retro
+import stable_retro as retro
 import pandas as pd
 import json
 import numpy as np
@@ -22,7 +22,7 @@ from tqdm_joblib import tqdm_joblib
 from tqdm import tqdm
 import logging
 from mario_replays.utils import make_mp4, create_sidecar_dict, get_variables_from_replay
-from cneuromod_vg_utils.psychophysics import (
+from videogames_utils.psychophysics import (
     compute_luminance,
     compute_optical_flow,
     audio_envelope_per_frame,

--- a/code/mario_replays/utils/utils.py
+++ b/code/mario_replays/utils/utils.py
@@ -1,12 +1,12 @@
 """Utility functions for Mario replay processing."""
 
-import retro
+import stable_retro as retro
 import os.path as op
 import numpy as np
-from retro.enums import State
+from stable_retro.enums import State
 
-from cneuromod_vg_utils.replay import get_variables_from_replay as _get_variables_from_replay_general
-from cneuromod_vg_utils.video import make_gif, make_mp4, make_webp
+from videogames_utils.replay import get_variables_from_replay as _get_variables_from_replay_general
+from videogames_utils.video import make_gif, make_mp4, make_webp
 
 
 def get_variables_from_replay(

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -2,7 +2,7 @@
 # All values can be overridden via command-line flags
 
 # Dataset paths
-mario_dataset: ../mario          # Path to mario dataset root
+mario_dataset: sourcedata/mario         # Path to mario dataset root
 stimuli_path: null               # Path to stimuli (defaults to {mario_dataset}/stimuli)
 output_dir: ./   # Output directory for derivatives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "Pillow",
     "invoke",
     "airoh",
-    "cneuromod_vg_utils @ git+https://github.com/courtois-neuromod/videogames.utils.git"
+    "videogames_utils @ git+https://github.com/courtois-neuromod/videogames.utils.git"
 ]
 description = "A set of functions and code to replay games of Super Mario Bros. acquired in the CNeuroMod mario dataset."
 authors = [{name = "Yann Harel"}]

--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,7 @@ def create_replays(
     c : invoke.Context
         The Invoke context (automatically provided).
     datapath : str, optional
-        Path to the mario dataset root. Defaults to mario_dataset from invoke.yaml.
+        Path to the mario dataset root. Defaults to sourcedata/mario from invoke.yaml.
     stimuli : str, optional
         Path to stimuli files. Defaults to stimuli_path from invoke.yaml.
     output : str, optional


### PR DESCRIPTION
README.md:
I added 'pip install invoke' before using invoke for the first time with `invoke setup-env`
I also added `invoke setup-mario-dataset` to avoid `FileNotFoundError: ❌ Mario dataset not found at: ../mario`

In utils.py and replays.py:
I replaced `import retro` with `import stable_retro as retro`. This is the new way to import stable-retro.

In invoke.yaml:
I replaced `mario_dataset` form ../mario, producing `FileNotFoundError: ❌ Mario dataset not found at: ../mario`, by `sourcedata/mario` wich is the default path creat by  `invoke setup-mario-dataset` 